### PR TITLE
Add sticky top navigation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,20 +1,68 @@
 <template>
-  <main class="app">
-    <h1>Mediacenter Web</h1>
-    <p>Leere Vue-Anwendung bereit zur Entwicklung.</p>
-  </main>
+  <div class="app">
+    <nav class="top-nav">
+      <ul>
+        <li><a href="#movies">Movie</a></li>
+        <li><a href="#bilder">Bilder</a></li>
+        <li><a href="#studio">Studio</a></li>
+        <li><a href="#darsteller">Darsteller</a></li>
+      </ul>
+    </nav>
+
+    <main class="content">
+      <section>
+        <h1 id="movies">Mediacenter Web</h1>
+        <p>Leere Vue-Anwendung bereit zur Entwicklung.</p>
+      </section>
+    </main>
+  </div>
 </template>
 
 <style scoped>
 .app {
-  display: grid;
-  place-items: center;
   min-height: 100vh;
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   background: #f6f7fb;
   color: #1f1f24;
-  text-align: center;
+}
+
+.top-nav {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: #1f1f24;
+  color: #ffffff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.top-nav ul {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
   margin: 0;
+  padding: 1rem 2rem;
+  list-style: none;
+}
+
+.top-nav a {
+  color: inherit;
+  text-decoration: none;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  transition: color 0.2s ease;
+}
+
+.top-nav a:hover,
+.top-nav a:focus-visible {
+  color: #f0b429;
+}
+
+.content {
+  display: grid;
+  place-items: center;
+  padding: 4rem 1.5rem;
+  text-align: center;
 }
 
 h1 {


### PR DESCRIPTION
## Summary
- add a sticky obere Navigationsleiste mit den Punkten Movie, Bilder, Studio und Darsteller
- strukturieren die Startseite neu, um Platz für die Navigation und Inhalte zu schaffen
- ergänzen Styles für die neue Navigation sowie das Seitenlayout

## Testing
- `npm run lint` *(fails: fehlende Abhängigkeit `typescript-eslint` in der Umgebung)*

------
https://chatgpt.com/codex/tasks/task_e_68d52e23ff588323b93a743228727230