### PR TITLE
Add simple router with navigation component

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,19 +1,15 @@
+<script setup lang="ts">
+import { RouterView } from './router'
+
+import TopNavigation from './components/TopNavigation.vue'
+</script>
+
 <template>
   <div class="app">
-    <nav class="top-nav">
-      <ul>
-        <li><a href="#movies">Movie</a></li>
-        <li><a href="#bilder">Bilder</a></li>
-        <li><a href="#studio">Studio</a></li>
-        <li><a href="#darsteller">Darsteller</a></li>
-      </ul>
-    </nav>
+    <TopNavigation />
 
     <main class="content">
-      <section>
-        <h1 id="movies">Mediacenter Web</h1>
-        <p>Leere Vue-Anwendung bereit zur Entwicklung.</p>
-      </section>
+      <RouterView />
     </main>
   </div>
 </template>
@@ -26,52 +22,7 @@
   color: #1f1f24;
 }
 
-.top-nav {
-  position: sticky;
-  top: 0;
-  z-index: 10;
-  background: #1f1f24;
-  color: #ffffff;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-}
-
-.top-nav ul {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 2rem;
-  margin: 0;
-  padding: 1rem 2rem;
-  list-style: none;
-}
-
-.top-nav a {
-  color: inherit;
-  text-decoration: none;
-  font-weight: 600;
-  letter-spacing: 0.03em;
-  transition: color 0.2s ease;
-}
-
-.top-nav a:hover,
-.top-nav a:focus-visible {
-  color: #f0b429;
-}
-
 .content {
-  display: grid;
-  place-items: center;
-  padding: 4rem 1.5rem;
-  text-align: center;
-}
-
-h1 {
-  font-size: 2.5rem;
-  margin-bottom: 1rem;
-}
-
-p {
-  font-size: 1.125rem;
-  margin: 0;
+  min-height: calc(100vh - 72px);
 }
 </style>

--- a/src/components/TopNavigation.vue
+++ b/src/components/TopNavigation.vue
@@ -1,0 +1,48 @@
+<template>
+  <nav class="top-nav">
+    <ul>
+      <li><RouterLink to="/movies">Filme</RouterLink></li>
+      <li><RouterLink to="/bilder">Bilder</RouterLink></li>
+      <li><RouterLink to="/studio">Studio</RouterLink></li>
+      <li><RouterLink to="/darsteller">Darsteller</RouterLink></li>
+    </ul>
+  </nav>
+</template>
+
+<style scoped>
+.top-nav {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: #1f1f24;
+  color: #ffffff;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.top-nav ul {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 2rem;
+  margin: 0;
+  padding: 1rem 2rem;
+  list-style: none;
+}
+
+.top-nav a {
+  color: inherit;
+  text-decoration: none;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  transition: color 0.2s ease;
+}
+
+.top-nav a.router-link-active {
+  color: #f0b429;
+}
+
+.top-nav a:hover,
+.top-nav a:focus-visible {
+  color: #f0b429;
+}
+</style>

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { createApp } from 'vue'
 import App from './App.vue'
+import router from './router'
 import './assets/main.css'
 
-createApp(App).mount('#app')
+createApp(App).use(router).mount('#app')

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,0 +1,254 @@
+import type { App, Component, ComputedRef } from 'vue'
+import { computed, defineComponent, h, inject, ref, shallowRef } from 'vue'
+
+type NavigationType = 'push' | 'replace' | 'pop'
+
+type AsyncComponent = () => Promise<{ default?: Component } | Component>
+
+type RouteRecord = {
+  path: string
+  name?: string
+  component?: Component | AsyncComponent
+  redirect?: string
+}
+
+type HistoryListener = (path: string, type: NavigationType) => void
+
+type History = {
+  location: () => string
+  push: (path: string) => void
+  replace: (path: string) => void
+  listen: (listener: HistoryListener) => void
+}
+
+const ROUTER_KEY = Symbol('router')
+
+function normalizePath(path: string) {
+  if (!path.startsWith('/')) {
+    return `/${path}`
+  }
+
+  return path
+}
+
+function createWebHistory(): History {
+  const listeners = new Set<HistoryListener>()
+
+  const getLocation = () => normalizePath(window.location.pathname || '/')
+
+  const notify = (type: NavigationType) => {
+    const path = getLocation()
+    listeners.forEach((listener) => listener(path, type))
+  }
+
+  window.addEventListener('popstate', () => notify('pop'))
+
+  return {
+    location: getLocation,
+    push(path) {
+      const normalized = normalizePath(path)
+      if (normalized === getLocation()) {
+        return
+      }
+
+      window.history.pushState({}, '', normalized)
+      notify('push')
+    },
+    replace(path) {
+      const normalized = normalizePath(path)
+      window.history.replaceState({}, '', normalized)
+      notify('replace')
+    },
+    listen(listener) {
+      listeners.add(listener)
+    },
+  }
+}
+
+type RouterOptions = {
+  history?: History
+  routes: RouteRecord[]
+}
+
+type Router = {
+  currentRoute: ComputedRef<{ path: string }>
+  currentComponent: ReturnType<typeof shallowRef<Component | null>>
+  push: (path: string) => void
+  replace: (path: string) => void
+  install: (app: App) => void
+}
+
+async function resolveComponent(component?: Component | AsyncComponent) {
+  if (!component) {
+    return null
+  }
+
+  if (typeof component === 'function') {
+    const resolved = await component()
+    if (typeof resolved === 'object' && 'default' in resolved && resolved.default) {
+      return resolved.default
+    }
+
+    return resolved as Component
+  }
+
+  return component
+}
+
+function createRouter(options: RouterOptions): Router {
+  const history = options.history ?? createWebHistory()
+  const routes = options.routes
+  const currentPath = ref(history.location())
+  const currentComponent = shallowRef<Component | null>(null)
+  let latestNavigationId = 0
+
+  const matchRoute = (path: string): RouteRecord | undefined =>
+    routes.find((route) => normalizePath(route.path) === normalizePath(path))
+
+  const applyRoute = async (path: string, type: NavigationType) => {
+    latestNavigationId += 1
+    const navigationId = latestNavigationId
+    let targetPath = normalizePath(path)
+    const record = matchRoute(targetPath)
+
+    if (record?.redirect) {
+      const redirectTarget = normalizePath(record.redirect)
+      if (redirectTarget === targetPath) {
+        return
+      }
+
+      if (type === 'replace' || type === 'pop') {
+        history.replace(redirectTarget)
+      } else {
+        history.push(redirectTarget)
+      }
+      return
+    }
+
+    currentPath.value = targetPath
+
+    const component = await resolveComponent(record?.component)
+
+    if (navigationId !== latestNavigationId) {
+      return
+    }
+
+    currentComponent.value = component
+  }
+
+  history.listen((path, type) => {
+    void applyRoute(path, type)
+  })
+
+  void applyRoute(currentPath.value, 'replace')
+
+  const router = {
+    currentRoute: computed(() => ({ path: currentPath.value })),
+    currentComponent,
+    push(path: string) {
+      history.push(path)
+    },
+    replace(path: string) {
+      history.replace(path)
+    },
+    install(app: App) {
+      app.provide(ROUTER_KEY, router)
+      app.component('RouterLink', RouterLink)
+      app.component('RouterView', RouterView)
+    },
+  }
+
+  return router
+}
+
+function useRouter(): Router {
+  const router = inject<Router>(ROUTER_KEY)
+  if (!router) {
+    throw new Error('Router instance is not available.')
+  }
+
+  return router
+}
+
+const RouterView = defineComponent({
+  name: 'RouterView',
+  setup() {
+    const router = useRouter()
+    return () => {
+      const component = router.currentComponent.value
+      return component ? h(component) : null
+    }
+  },
+})
+
+const RouterLink = defineComponent({
+  name: 'RouterLink',
+  props: {
+    to: {
+      type: String,
+      required: true,
+    },
+  },
+  setup(props, { slots }) {
+    const router = useRouter()
+    const isActive = computed(() => router.currentRoute.value.path === normalizePath(props.to))
+
+    const onClick = (event: MouseEvent) => {
+      if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey) {
+        return
+      }
+
+      event.preventDefault()
+      if (!isActive.value) {
+        router.push(props.to)
+      }
+    }
+
+    return () =>
+      h(
+        'a',
+        {
+          href: normalizePath(props.to),
+          class: {
+            'router-link-active': isActive.value,
+          },
+          'aria-current': isActive.value ? 'page' : undefined,
+          onClick,
+        },
+        slots.default ? slots.default() : []
+      )
+  },
+})
+
+export { createRouter, createWebHistory, RouterLink, RouterView, useRouter }
+
+const router = createRouter({
+  routes: [
+    {
+      path: '/',
+      redirect: '/movies',
+    },
+    {
+      path: '/movies',
+      name: 'movies',
+      component: () => import('../views/MoviesView.vue'),
+    },
+    {
+      path: '/bilder',
+      name: 'bilder',
+      component: () => import('../views/BilderView.vue'),
+    },
+    {
+      path: '/studio',
+      name: 'studio',
+      component: () => import('../views/StudioView.vue'),
+    },
+    {
+      path: '/darsteller',
+      name: 'darsteller',
+      component: () => import('../views/DarstellerView.vue'),
+    },
+  ],
+})
+
+export default router

--- a/src/views/BilderView.vue
+++ b/src/views/BilderView.vue
@@ -1,0 +1,25 @@
+<template>
+  <section class="view">
+    <h1>Bilder</h1>
+    <p>Organisiere und entdecke Galerien deiner Lieblingsmomente.</p>
+  </section>
+</template>
+
+<style scoped>
+.view {
+  display: grid;
+  place-items: center;
+  padding: 4rem 1.5rem;
+  text-align: center;
+}
+
+h1 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+p {
+  font-size: 1.125rem;
+  margin: 0;
+}
+</style>

--- a/src/views/DarstellerView.vue
+++ b/src/views/DarstellerView.vue
@@ -1,0 +1,25 @@
+<template>
+  <section class="view">
+    <h1>Darsteller</h1>
+    <p>Behalte Schauspielerinnen und Schauspieler sowie ihre Rollen im Blick.</p>
+  </section>
+</template>
+
+<style scoped>
+.view {
+  display: grid;
+  place-items: center;
+  padding: 4rem 1.5rem;
+  text-align: center;
+}
+
+h1 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+p {
+  font-size: 1.125rem;
+  margin: 0;
+}
+</style>

--- a/src/views/MoviesView.vue
+++ b/src/views/MoviesView.vue
@@ -1,0 +1,25 @@
+<template>
+  <section class="view">
+    <h1>Filme</h1>
+    <p>Hier könnten Highlights und Empfehlungen aus der Mediathek stehen.</p>
+  </section>
+</template>
+
+<style scoped>
+.view {
+  display: grid;
+  place-items: center;
+  padding: 4rem 1.5rem;
+  text-align: center;
+}
+
+h1 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+p {
+  font-size: 1.125rem;
+  margin: 0;
+}
+</style>

--- a/src/views/StudioView.vue
+++ b/src/views/StudioView.vue
@@ -1,0 +1,25 @@
+<template>
+  <section class="view">
+    <h1>Studio</h1>
+    <p>Verwalte Produktionen, Projekte und neue Ideen an einem Ort.</p>
+  </section>
+</template>
+
+<style scoped>
+.view {
+  display: grid;
+  place-items: center;
+  padding: 4rem 1.5rem;
+  text-align: center;
+}
+
+h1 {
+  font-size: 2.5rem;
+  margin-bottom: 1rem;
+}
+
+p {
+  font-size: 1.125rem;
+  margin: 0;
+}
+</style>


### PR DESCRIPTION
## Summary
- add a lightweight client-side router implementation that registers routes for the movies, bilder, studio and darsteller views
- extract the top navigation into its own component and wire it up with router-powered links
- create placeholder views for each navigation target and render them through the router view in the main layout

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d52ef023a08323845bd52a1b4167af