### PR TITLE
Add floating add button to media views

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,35 +2,55 @@ import js from '@eslint/js'
 import pluginVue from 'eslint-plugin-vue'
 import globals from 'globals'
 import tseslint from 'typescript-eslint'
+import vueParser from 'vue-eslint-parser'
 
 export default tseslint.config(
   {
     ignores: ['dist'],
   },
   {
-    files: ['**/*.{js,mjs,cjs,jsx,ts,tsx,vue}'],
-    extends: [
-      js.configs.recommended,
-      ...pluginVue.configs['flat/essential'],
-      ...tseslint.configs.recommended,
-    ],
+    files: ['**/*.vue'],
     languageOptions: {
+      parser: vueParser,
       parserOptions: {
+        parser: tseslint.parser,
         ecmaVersion: 'latest',
         sourceType: 'module',
-        extraFileExtensions: ['.vue'],
       },
       globals: {
         ...globals.browser,
       },
     },
+    extends: [
+      ...pluginVue.configs['flat/essential'],
+      ...tseslint.configs.recommended,
+    ],
   },
   {
-    files: ['**/*.vue'],
+    files: ['**/*.{ts,tsx}'],
     languageOptions: {
+      parser: tseslint.parser,
       parserOptions: {
-        parser: tseslint.parser,
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+      globals: {
+        ...globals.browser,
       },
     },
+    extends: [...tseslint.configs.recommended],
   },
+  {
+    files: ['**/*.{js,mjs,cjs,jsx}'],
+    languageOptions: {
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+      globals: {
+        ...globals.browser,
+      },
+    },
+    extends: [js.configs.recommended],
+  }
 )

--- a/src/components/FloatingActionButton.vue
+++ b/src/components/FloatingActionButton.vue
@@ -1,0 +1,62 @@
+<template>
+  <button
+    class="floating-action-button"
+    type="button"
+    :aria-label="ariaLabel"
+    @click="onClick"
+  >
+    <span aria-hidden="true">+</span>
+  </button>
+</template>
+
+<script setup lang="ts">
+import { toRefs } from 'vue';
+
+const props = withDefaults(defineProps<{ ariaLabel?: string }>(), {
+  ariaLabel: 'Neues Element hinzufügen',
+});
+
+const emit = defineEmits<{ (event: 'click'): void }>();
+
+const onClick = () => emit('click');
+
+const { ariaLabel } = toRefs(props);
+</script>
+
+<style scoped>
+.floating-action-button {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  width: 25px;
+  height: 25px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: none;
+  background: linear-gradient(135deg, #ff7a59, #ff3d81);
+  color: #ffffff;
+  font-size: 1.25rem;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: 0 0.5rem 1.5rem rgba(255, 61, 129, 0.35);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.floating-action-button:hover,
+.floating-action-button:focus-visible {
+  transform: scale(1.05);
+  box-shadow: 0 0.75rem 2rem rgba(255, 61, 129, 0.45);
+}
+
+.floating-action-button:focus-visible {
+  outline: 2px solid #ffffff;
+  outline-offset: 3px;
+}
+
+.floating-action-button span {
+  pointer-events: none;
+  margin-top: -2px;
+}
+</style>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -2,6 +2,6 @@
 
 declare module '*.vue' {
   import type { DefineComponent } from 'vue'
-  const component: DefineComponent<{}, {}, any>
+  const component: DefineComponent<Record<string, never>, Record<string, never>, unknown>
   export default component
 }

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -84,7 +84,7 @@ async function resolveComponent(component?: Component | AsyncComponent) {
   }
 
   if (typeof component === 'function') {
-    const resolved = await component()
+    const resolved = await (component as AsyncComponent)()
     if (typeof resolved === 'object' && 'default' in resolved && resolved.default) {
       return resolved.default
     }
@@ -108,7 +108,7 @@ function createRouter(options: RouterOptions): Router {
   const applyRoute = async (path: string, type: NavigationType) => {
     latestNavigationId += 1
     const navigationId = latestNavigationId
-    let targetPath = normalizePath(path)
+    const targetPath = normalizePath(path)
     const record = matchRoute(targetPath)
 
     if (record?.redirect) {

--- a/src/views/BilderView.vue
+++ b/src/views/BilderView.vue
@@ -2,8 +2,23 @@
   <section class="view">
     <h1>Bilder</h1>
     <p>Organisiere und entdecke Galerien deiner Lieblingsmomente.</p>
+    <FloatingActionButton aria-label="Neues Bild hinzufügen" @click="createImage" />
   </section>
 </template>
+
+<script setup lang="ts">
+import FloatingActionButton from '../components/FloatingActionButton.vue';
+
+const createImage = () => {
+  const newImage = {
+    id: Date.now(),
+    title: 'Neues Bild',
+    createdAt: new Date().toISOString(),
+  };
+
+  console.log('Neues Bild-Objekt erstellt:', newImage);
+};
+</script>
 
 <style scoped>
 .view {

--- a/src/views/DarstellerView.vue
+++ b/src/views/DarstellerView.vue
@@ -2,8 +2,23 @@
   <section class="view">
     <h1>Darsteller</h1>
     <p>Behalte Schauspielerinnen und Schauspieler sowie ihre Rollen im Blick.</p>
+    <FloatingActionButton aria-label="Neuen Darsteller hinzufügen" @click="createActor" />
   </section>
 </template>
+
+<script setup lang="ts">
+import FloatingActionButton from '../components/FloatingActionButton.vue';
+
+const createActor = () => {
+  const newActor = {
+    id: Date.now(),
+    name: 'Neue Darstellerin',
+    createdAt: new Date().toISOString(),
+  };
+
+  console.log('Neues Darsteller-Objekt erstellt:', newActor);
+};
+</script>
 
 <style scoped>
 .view {

--- a/src/views/MoviesView.vue
+++ b/src/views/MoviesView.vue
@@ -2,8 +2,23 @@
   <section class="view">
     <h1>Filme</h1>
     <p>Hier könnten Highlights und Empfehlungen aus der Mediathek stehen.</p>
+    <FloatingActionButton aria-label="Neuen Film hinzufügen" @click="createMovie" />
   </section>
 </template>
+
+<script setup lang="ts">
+import FloatingActionButton from '../components/FloatingActionButton.vue';
+
+const createMovie = () => {
+  const newMovie = {
+    id: Date.now(),
+    title: 'Neuer Film',
+    createdAt: new Date().toISOString(),
+  };
+
+  console.log('Neues Film-Objekt erstellt:', newMovie);
+};
+</script>
 
 <style scoped>
 .view {

--- a/src/views/StudioView.vue
+++ b/src/views/StudioView.vue
@@ -2,8 +2,23 @@
   <section class="view">
     <h1>Studio</h1>
     <p>Verwalte Produktionen, Projekte und neue Ideen an einem Ort.</p>
+    <FloatingActionButton aria-label="Neues Studio-Projekt hinzufügen" @click="createProject" />
   </section>
 </template>
+
+<script setup lang="ts">
+import FloatingActionButton from '../components/FloatingActionButton.vue';
+
+const createProject = () => {
+  const newProject = {
+    id: Date.now(),
+    title: 'Neues Projekt',
+    createdAt: new Date().toISOString(),
+  };
+
+  console.log('Neues Studio-Projekt erstellt:', newProject);
+};
+</script>
 
 <style scoped>
 .view {


### PR DESCRIPTION
## Summary
- add a reusable FloatingActionButton component with a fixed circular plus button
- show the button in the Bilder, Darsteller, Filme und Studio Ansichten und verknüpfe Klick-Handler zum Erstellen neuer Objekte
- aktualisiere ESLint- und TypeScript-Hilfsdefinitionen, damit Linting und Typechecks weiterhin funktionieren

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d5371c260c8323b42295a5bf2f6f40